### PR TITLE
Set defaultDataLocality to best-effort

### DIFF
--- a/core-apps/base/longhorn/release.yaml
+++ b/core-apps/base/longhorn/release.yaml
@@ -103,7 +103,7 @@ spec:
       snapshotterReplicaCount: 3
     defaultSettings:
       defaultDataPath: /opt/local-path-provisioner/longhorn/
-      defaultDataLocality: disabled
+      defaultDataLocality: best-effort
       replicaSoftAntiAffinity: false
       replicaAutoBalance: disabled
       storageOverProvisioningPercentage: 100


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated default data locality setting from `disabled` to `best-effort` in Longhorn release.yaml file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->