### PR TITLE
Set guaranteedInstanceManagerCPU to 20%

### DIFF
--- a/core-apps/base/longhorn/release.yaml
+++ b/core-apps/base/longhorn/release.yaml
@@ -125,6 +125,7 @@ spec:
       replicaDiskSoftAntiAffinity: false
       nodeDownPodDeletionPolicy: do-nothing
       nodeDrainPolicy: block-if-contains-last-replica
+      guaranteedInstanceManagerCPU: 20
     longhornManager:
       log:
         format: plain


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for Longhorn to guarantee 20 CPU units for the instance manager, enhancing resource management and potentially improving performance.
  
- **Bug Fixes**
	- No reported bugs addressed in this release.

- **Documentation**
	- Updated documentation to include the new configuration option and its implications for resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->