### PR TITLE
Updated metallb, disabled metallb speakers

### DIFF
--- a/core-apps/clusters/k8s-01/metallb/release.yaml
+++ b/core-apps/clusters/k8s-01/metallb/release.yaml
@@ -6,8 +6,10 @@ spec:
   chart:
     spec:
       chart: metallb
-      version: v0.11.0
+      version: v0.14.8
   values:
+    speaker:
+      enabled: false
     configInline:
       address-pools:
         - name: default


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the MetalLB chart to version `v0.14.8`.
	- Introduced a new configuration option to disable the `speaker` component.

- **Bug Fixes**
	- Retained existing configurations for address pools, ensuring stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->