### PR TITLE
Changed nodeAffinity for prod-minio pool-0

### DIFF
--- a/core-apps/base/minio-tenant/statefulset.yaml
+++ b/core-apps/base/minio-tenant/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
                   - key: kubernetes.io/hostname
                     operator: In
                     values:
-                      - hwn04.k8s-01.kontur.io
+                      - hwn03.k8s-01.kontur.io
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
  - Updated MinIO tenant `StatefulSet` node affinity settings
  - Adjusted pod deployment to target a different Kubernetes node

<!-- end of auto-generated comment: release notes by coderabbit.ai -->