### PR TITLE
Fixed tigera-operator ns; update metallb

### DIFF
--- a/core-apps/base/tigera-operator/kustomization.yaml
+++ b/core-apps/base/tigera-operator/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: default
 resources:
   - release.yaml

--- a/core-apps/clusters/k8s-02/kustomization.yaml
+++ b/core-apps/clusters/k8s-02/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ../../base/victoriametrics-operator
   - ../../base/local-path-provisioner
   - ../../base/calico
-  - ../../base/nginx-ingress
+#  - ../../base/nginx-ingress
   - ../../base/cert-manager-crds
   - ../../base/metallb
   - ../../base/metrics-server
@@ -25,7 +25,7 @@ patchesStrategicMerge:
   - victoriametrics-operator/release.yaml
   - local-path-provisioner/configmap.yaml
   - local-path-provisioner/deployment.yaml
-  - nginx-ingress/release.yaml
+#  - nginx-ingress/release.yaml
   - metallb/release.yaml
   - tigera-operator/release.yaml
   - kube-prometheus-operator/prometheus-operator-deployment.yaml

--- a/core-apps/clusters/k8s-02/metallb/release.yaml
+++ b/core-apps/clusters/k8s-02/metallb/release.yaml
@@ -6,7 +6,7 @@ spec:
   chart:
     spec:
       chart: metallb
-      version: v0.11.0
+      version: v0.14.8
   values:
     configInline:
       address-pools:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an explicit default namespace configuration to streamline deployments.
	- Excluded legacy ingress resource references from the deployment setup.
	- Upgraded the network load-balancing component to a newer version for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->