### PR TITLE
Removed legacy postgres exporters

### DIFF
--- a/apps/clusters/k8s-01/kustomization.yaml
+++ b/apps/clusters/k8s-01/kustomization.yaml
@@ -12,7 +12,6 @@ resources:
   - ../../base/kube-prometheus/prometheus
   - ../../base/kube-prometheus/prometheus-adapter
   - ../../base/kube-prometheus/victoriametrics
-  - ../../base/postgres-exporter
   - ../../base/fluentbit
   - ../../base/flux
   # - ../../base/cert-manager


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the Postgres exporter from the managed configuration, meaning it will no longer be deployed as one of the system's resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->