### PR TITLE
Upgraded tigera-operator to v3.28.3 on k8s-01

### DIFF
--- a/core-apps/base/tigera-operator/release.yaml
+++ b/core-apps/base/tigera-operator/release.yaml
@@ -1,7 +1,4 @@
-# Despite that we specify namespace as default, resources will be installed in calico-system and tigera-operator namespaces
-# they are hardcoded https://projectcalico.docs.tigera.io/archive/v3.21/getting-started/kubernetes/helm
-# Also helm release created in default namespace because originally it was created manually in default namespace
-
+# https://docs.tigera.io/calico/3.28/getting-started/kubernetes/helm
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
@@ -11,7 +8,7 @@ spec:
   chart:
     spec:
       chart: tigera-operator
-      version: 3.27.0
+      version: 3.28.3
       sourceRef:
         kind: HelmRepository
         name: projectcalico

--- a/core-apps/clusters/k8s-02/tigera-operator/release.yaml
+++ b/core-apps/clusters/k8s-02/tigera-operator/release.yaml
@@ -1,6 +1,4 @@
-# Despite that we specify namespace as default, resources will be installed in calico-system and tigera-operator namespaces
-# they are hardcoded https://docs.tigera.io/calico/3.28/getting-started/kubernetes/helm
-
+# https://docs.tigera.io/calico/3.28/getting-started/kubernetes/helm
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the operator deployment to version 3.28.3 for enhanced performance.
  
- **Documentation**
  - Streamlined installation notes by updating links to the latest Calico documentation and clarifying relevant guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->