### PR TITLE
Upgraded crunchy-postgres-operator from 5.5.0 to 5.7.4

### DIFF
--- a/core-apps/sources/pgo-kustomize-installer.yaml
+++ b/core-apps/sources/pgo-kustomize-installer.yaml
@@ -12,6 +12,6 @@ spec:
   interval: 1m0s
   ref:
     # branch: main
-    commit: e02a70d683d954d8927a59e25d07d9c04c05fb63
+    commit: 47bcbe6c95e81db2cfecee8f34b1a9389d109338
   timeout: 60s
   url: 'https://github.com/konturio/postgres-operator-examples'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version reference for the installer configuration to ensure the most up-to-date improvements are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->