### PR TITLE
Disabled heavy collectors

### DIFF
--- a/apps/base/postgres-exporter-pgo/prod-insights-api-db-pg17/release.yaml
+++ b/apps/base/postgres-exporter-pgo/prod-insights-api-db-pg17/release.yaml
@@ -51,6 +51,10 @@ spec:
         sslmode: require
       logLevel: "info"
       logFormat: "logfmt"
+      extraArgs:
+        - --disable-settings-metrics
+        - --exclude-collector=statements
+        - --exclude-collector=locks
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
@@ -106,3 +110,7 @@ spec:
         sslmode: require
       logLevel: "info"
       logFormat: "logfmt"
+      extraArgs:
+        - --disable-settings-metrics
+        - --exclude-collector=statements
+        - --exclude-collector=locks

--- a/apps/base/postgres-exporter-pgo/test-insights-api-db-pg17/release.yaml
+++ b/apps/base/postgres-exporter-pgo/test-insights-api-db-pg17/release.yaml
@@ -41,6 +41,10 @@ spec:
     serviceAccount:
       create: true
     config:
+      extraArgs:
+        - --disable-settings-metrics
+        - --exclude-collector=statements
+        - --exclude-collector=locks
       datasource:
         host: db-insights-api-pg17-primary.test-insights-api.svc
         user: insights-api
@@ -106,3 +110,7 @@ spec:
         sslmode: require
       logLevel: "info"
       logFormat: "logfmt"
+      extraArgs:
+        - --disable-settings-metrics
+        - --exclude-collector=statements
+        - --exclude-collector=locks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configurations for database monitoring exporters to disable settings metrics and exclude "statements" and "locks" collectors. This change applies to both primary and replica environments. No other configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->