### PR TITLE
Moving nvidia-device-plugin under Flux management

### DIFF
--- a/core-apps/base/nvidia-device-plugin/configmap-values.yaml
+++ b/core-apps/base/nvidia-device-plugin/configmap-values.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nvdp-configmap
+  namespace: nvidia-device-plugin
+data:
+  configmap-values.yaml: |-
+    image:
+      repository: nvcr.io/nvidia/k8s-device-plugin
+      tag: v0.17.2
+
+    compatWithCPUManager: null
+    migStrategy: null
+    failOnInitError: null
+    deviceListStrategy: null
+    deviceIDStrategy: null
+    nvidiaDriverRoot: null
+    gdsEnabled: null
+    mofedEnabled: null
+    deviceDiscoveryStrategy: null
+
+    resources:
+      limits:
+        cpu: 4
+        memory: 24Gi
+      requests:
+        cpu: 200m
+        memory: 128Mi
+    nodeSelector: {}
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            # On discrete-GPU based systems NFD adds the following label where 10de is the NVIDIA PCI vendor ID
+            - key: feature.node.kubernetes.io/pci-10de.present
+              operator: In
+              values:
+              - "true"
+          - matchExpressions:
+            # On some Tegra-based systems NFD detects the CPU vendor ID as NVIDIA
+            - key: feature.node.kubernetes.io/cpu-model.vendor_id
+              operator: In
+              values:
+              - "NVIDIA"
+          - matchExpressions:
+            # We allow a GPU deployment to be forced by setting the following label to "true"
+            - key: "nvidia.com/gpu.present"
+              operator: In
+              values:
+              - "true"
+    tolerations:
+      # This toleration is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
+
+    # Mark this pod as a critical add-on; when enabled, the critical add-on
+    # scheduler reserves resources for critical add-on pods so that they can
+    # be rescheduled after a failure.
+    # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+    priorityClassName: "system-node-critical"
+
+    runtimeClassName: null
+
+    devicePlugin:
+      enabled: true
+
+    gfd:
+      enabled: false
+      nameOverride: gpu-feature-discovery
+      namespaceOverride: ""
+      noTimestamp: null
+      sleepInterval: null
+      securityContext:
+        # privileged access is required for the gpu-feature-discovery to access the
+        # vgpu info on a host.
+        # TODO: This should be optional and detected automatically.
+        privileged: true
+
+    # Helm dependency
+    nfd:
+      nameOverride: node-feature-discovery
+      enableNodeFeatureApi: false
+      master:
+        serviceAccount:
+          name: node-feature-discovery
+          create: true
+        config:
+          extraLabelNs: ["nvidia.com"]
+
+      worker:
+        tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Equal"
+          value: ""
+          effect: "NoSchedule"
+        - key: "nvidia.com/gpu"
+          operator: "Equal"
+          value: "present"
+          effect: "NoSchedule"
+        config:
+          sources:
+            pci:
+              deviceClassWhitelist:
+              - "02"
+              - "03"
+              deviceLabelFields:
+              - vendor
+
+    mps:
+      # root specifies the location where files and folders for managing MPS will
+      # be created. This includes a daemon-specific /dev/shm and pipe and log
+      # directories.
+      # Pipe directories will be created at {{ mps.root }}/{{ .ResourceName }}
+      root: "/run/nvidia/mps"
+
+    cdi:
+      # nvidiaHookPath specifies the path to the nvidia-cdi-hook or nvidia-ctk executables on the host.
+      # This is required to ensure that the generated CDI specification refers to the correct CDI hooks.
+      nvidiaHookPath: null

--- a/core-apps/base/nvidia-device-plugin/kustomization.yaml
+++ b/core-apps/base/nvidia-device-plugin/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nvidia-device-plugin
+resources:
+  - release.yaml
+  - configmap-values.yaml

--- a/core-apps/base/nvidia-device-plugin/release.yaml
+++ b/core-apps/base/nvidia-device-plugin/release.yaml
@@ -1,0 +1,26 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: nvdp
+  namespace: nvidia-device-plugin
+spec:
+  releaseName: nvdp
+  valuesFrom:
+    - kind: ConfigMap
+      name: nvdp-configmap
+      valuesKey: configmap-values.yaml
+  chart:
+    spec:
+      chart: nvidia-device-plugin
+      reconcileStrategy: ChartVersion
+      version: 0.17.2
+      sourceRef:
+        kind: HelmRepository
+        name: nvdp
+        namespace: flux-system
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  interval: 30m
+  suspend: false

--- a/core-apps/clusters/k8s-01/kustomization.yaml
+++ b/core-apps/clusters/k8s-01/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ../../base/longhorn
   - ../../base/velero
   - ../../base/tigera-operator
+  - ../../base/nvidia-device-plugin
   - ./resource-quota
   - ./limit-range
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment of the NVIDIA device plugin for Kubernetes, enabling GPU support on compatible nodes.
  * Introduced configuration options for enabling or disabling related features such as GPU Feature Discovery, Node Feature Discovery, and Multi-Process Service.
  * Provided customizable resource limits, node affinity, tolerations, and security settings for GPU workloads.

* **Chores**
  * Integrated the NVIDIA device plugin deployment into the cluster management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->