### PR TITLE
Enabled node-exporter text collector

### DIFF
--- a/apps/base/kube-prometheus/node-exporter/node-exporter-daemonset.yaml
+++ b/apps/base/kube-prometheus/node-exporter/node-exporter-daemonset.yaml
@@ -63,6 +63,9 @@ spec:
           mountPropagation: HostToContainer
           name: root
           readOnly: true
+        - mountPath: /var/lib/node_exporter/textfile_collector
+          readOnly: true
+          name: textfile
       - args:
         - --logtostderr
         - --secure-listen-address=[$(IP)]:9100
@@ -113,6 +116,10 @@ spec:
       - hostPath:
           path: /
         name: root
+      - hostPath:
+          path: /var/lib/node_exporter/textfile_collector
+          type: DirectoryOrCreate
+        name: textfile
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 10%


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mounting a host directory for the textfile collector in node-exporter, enabling collection of custom metrics from `/var/lib/node_exporter/textfile_collector`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->